### PR TITLE
fix: Allow submitting all forms using Enter key

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -54,7 +54,7 @@ export const Form = () => {
           />
 
           <Button
-            type="button"
+            type="submit"
             onClick={() => setCurrentStep("AddUsers")}
             disabled={!canGoToSecondStep}
           >


### PR DESCRIPTION
All forms can now be submitted using Enter key.

One thought I had: I could have made it so that when entering users, when you reach 3, the default submit would become the "send exchange" button, but I worry that because there is no confirmation prompt before sending, that it could lead to mistakes.